### PR TITLE
Add requirements file for missing Plotly dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 
 Python 3.10 以降を想定しています。
 
+依存パッケージは `requirements.txt` にまとめています。
+
 ```bash
-pip install streamlit pandas numpy plotly python-dateutil
+pip install -r requirements.txt
 ```
 
 ## 起動方法

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+streamlit>=1.32
+pandas>=2.2
+python-dateutil>=2.8
+plotly>=5.18


### PR DESCRIPTION
## Summary
- add a requirements.txt file capturing the Streamlit app's Python dependencies, including plotly
- update the setup instructions to reference the new requirements file

## Testing
- not run (documentation and dependency update only)


------
https://chatgpt.com/codex/tasks/task_e_68d8c1ac2adc8323a334a97efadf9d70