### PR TITLE
Adjust radio option text color

### DIFF
--- a/app.py
+++ b/app.py
@@ -1458,6 +1458,14 @@ def apply_brand_theme() -> None:
             margin: 0;
         }}
 
+        [data-testid="stRadio"] div[role="radiogroup"] > label:not(:has(div[aria-checked="true"])) > div:nth-of-type(2),
+        [data-testid="stRadio"] div[role="radiogroup"] > label:not(:has(div[aria-checked="true"])) > div:nth-of-type(2) *,
+        [data-testid="stRadio"] div[role="radiogroup"] > label:not(:has(div[aria-checked="true"])) div[data-testid="stMarkdownContainer"] {{
+            color: #3b4350 !important;
+        }}
+
+        [data-testid="stRadio"] div[role="radiogroup"] > label:has(div[aria-checked="true"]) > div:nth-of-type(2),
+        [data-testid="stRadio"] div[role="radiogroup"] > label:has(div[aria-checked="true"]) > div:nth-of-type(2) *,
         [data-testid="stRadio"] div[role="radiogroup"] > label:has(div[aria-checked="true"]) div[data-testid="stMarkdownContainer"] p,
         [data-testid="stRadio"] div[role="radiogroup"] > label:has(div[aria-checked="true"]) div[data-testid="stMarkdownContainer"] span {{
             color: var(--text-invert) !important;


### PR DESCRIPTION
## Summary
- darken the unselected Streamlit radio option text to improve contrast
- preserve the inverted color treatment for selected radio options

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d91f4842008323897ff5cb60dfc65a