### PR TITLE
Adjust quick action button text color to darker gray

### DIFF
--- a/app.py
+++ b/app.py
@@ -1477,7 +1477,7 @@ def apply_brand_theme() -> None:
 
         .quick-actions .stButton > button {{
             background: rgba(30, 76, 156, 0.12) !important;
-            color: var(--brand-navy) !important;
+            color: #3a4553 !important;
             border-radius: 12px !important;
             border: 1px solid rgba(30, 76, 156, 0.3) !important;
             font-weight: 600 !important;


### PR DESCRIPTION
## Summary
- update the quick action button styling to use a darker gray text color for better contrast

## Testing
- streamlit run app.py --server.port 8501 --server.headless true


------
https://chatgpt.com/codex/tasks/task_e_68d920a501cc83239dfe67e5bdec5100