### PR TITLE
Fix summary tab KeyError for empty datasets

### DIFF
--- a/app.py
+++ b/app.py
@@ -2137,7 +2137,7 @@ def render_projects_tab(full_df: pd.DataFrame, filtered_df: pd.DataFrame, master
 
 def render_summary_tab(df: pd.DataFrame, monthly: pd.DataFrame) -> None:
     st.subheader("集計 / 分析")
-    enriched = enrich_projects(df) if not df.empty else df
+    enriched = enrich_projects(df)
 
     total_revenue = enriched["受注金額"].sum()
     gross_profit = enriched["粗利額"].sum()


### PR DESCRIPTION
## Summary
- always enrich project data before computing summary metrics so derived columns exist even when the table is empty

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d921efb5488323aedf6e1b03771f76