### PR TITLE
Adjust timeline title color

### DIFF
--- a/app.py
+++ b/app.py
@@ -918,7 +918,10 @@ def create_timeline(df: pd.DataFrame, filters: FilterState, fiscal_range: Tuple[
         plot_bgcolor="white",
         paper_bgcolor="white",
         height=max(400, 40 * project_count + 200),
-        title=f"{filters.fiscal_year}年度 タイムライン",
+        title=dict(
+            text=f"{filters.fiscal_year}年度 タイムライン",
+            font=dict(color=BRAND_COLORS["slate"]),
+        ),
         xaxis=dict(
             range=[pd.to_datetime(start), pd.to_datetime(end)],
             tickformat="%m/%d",


### PR DESCRIPTION
## Summary
- update the timeline chart layout to explicitly render the title in the slate brand color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d927505c488323a033bb6bdf0ef167