### PR TITLE
Set legend text color to slate gray

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,6 +57,7 @@ BRAND_TEMPLATE = go.layout.Template(
             bgcolor="rgba(255,255,255,0.85)",
             bordercolor=BRAND_COLORS["cloud"],
             borderwidth=1,
+            font=dict(color=BRAND_COLORS["slate"], size=12),
         ),
         colorway=BRAND_COLORWAY,
     )


### PR DESCRIPTION
## Summary
- ensure the Plotly legend text uses the brand slate gray to improve contrast

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d928a8cba88323ad2e6f58053d8bd0