### PR TITLE
Fix axis title styling to prevent Plotly update error

### DIFF
--- a/app.py
+++ b/app.py
@@ -2149,14 +2149,14 @@ def apply_plotly_theme(fig: go.Figure) -> go.Figure:
     )
     fig.update_xaxes(
         tickfont=dict(color=theme["text_strong"]),
-        titlefont=dict(color=theme["text_strong"]),
+        title=dict(font=dict(color=theme["text_strong"])),
         gridcolor=theme["chart_grid"],
         zerolinecolor=theme["chart_grid"],
         linecolor=theme["chart_grid"],
     )
     fig.update_yaxes(
         tickfont=dict(color=theme["text_strong"]),
-        titlefont=dict(color=theme["text_strong"]),
+        title=dict(font=dict(color=theme["text_strong"])),
         gridcolor=theme["chart_grid"],
         zerolinecolor=theme["chart_grid"],
         linecolor=theme["chart_grid"],


### PR DESCRIPTION
## Summary
- replace deprecated axis `titlefont` usage with Plotly-compliant `title.font` updates in `apply_plotly_theme`
- ensure theme colors apply without raising errors when rendering figures

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d930104c288323918b8c6c0a315757