### PR TITLE
Fix Plotly axis title configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -1074,16 +1074,20 @@ def create_timeline(
         fig = go.Figure()
         fig.update_layout(
             xaxis=dict(
-                title="期間",
+                title=dict(
+                    text="期間",
+                    font=dict(color=BRAND_COLORS["slate"]),
+                ),
                 tickfont=dict(color=BRAND_COLORS["slate"]),
-                titlefont=dict(color=BRAND_COLORS["slate"]),
                 gridcolor=BRAND_COLORS["cloud"],
                 linecolor=BRAND_COLORS["cloud"],
             ),
             yaxis=dict(
-                title="案件名",
+                title=dict(
+                    text="案件名",
+                    font=dict(color=BRAND_COLORS["slate"]),
+                ),
                 tickfont=dict(color=BRAND_COLORS["slate"]),
-                titlefont=dict(color=BRAND_COLORS["slate"]),
                 gridcolor="rgba(0,0,0,0)",
             ),
             template=get_brand_template(),
@@ -3021,26 +3025,32 @@ def render_summary_tab(df: pd.DataFrame, monthly: pd.DataFrame) -> None:
         plot_bgcolor="white",
         paper_bgcolor="white",
         xaxis=dict(
-            title="年月",
+            title=dict(
+                text="年月",
+                font=dict(color=BRAND_COLORS["slate"]),
+            ),
             tickfont=dict(color=BRAND_COLORS["slate"]),
-            titlefont=dict(color=BRAND_COLORS["slate"]),
             gridcolor=BRAND_COLORS["cloud"],
             linecolor=BRAND_COLORS["cloud"],
         ),
         yaxis=dict(
-            title="金額",
+            title=dict(
+                text="金額",
+                font=dict(color=BRAND_COLORS["slate"]),
+            ),
             gridcolor=BRAND_COLORS["cloud"],
             zerolinecolor=BRAND_COLORS["cloud"],
             tickfont=dict(color=BRAND_COLORS["slate"]),
-            titlefont=dict(color=BRAND_COLORS["slate"]),
         ),
         yaxis2=dict(
-            title="粗利率 (%)",
+            title=dict(
+                text="粗利率 (%)",
+                font=dict(color=BRAND_COLORS["slate"]),
+            ),
             overlaying="y",
             side="right",
             gridcolor="rgba(0,0,0,0)",
             tickfont=dict(color=BRAND_COLORS["slate"]),
-            titlefont=dict(color=BRAND_COLORS["slate"]),
         ),
         height=480,
         margin=dict(t=60, b=40, l=10, r=10, pad=10),
@@ -3079,26 +3089,32 @@ def render_summary_tab(df: pd.DataFrame, monthly: pd.DataFrame) -> None:
         plot_bgcolor="white",
         paper_bgcolor="white",
         xaxis=dict(
-            title="年月",
+            title=dict(
+                text="年月",
+                font=dict(color=BRAND_COLORS["slate"]),
+            ),
             tickfont=dict(color=BRAND_COLORS["slate"]),
-            titlefont=dict(color=BRAND_COLORS["slate"]),
             gridcolor=BRAND_COLORS["cloud"],
             linecolor=BRAND_COLORS["cloud"],
         ),
         yaxis=dict(
-            title="キャッシュフロー",
+            title=dict(
+                text="キャッシュフロー",
+                font=dict(color=BRAND_COLORS["slate"]),
+            ),
             gridcolor=BRAND_COLORS["cloud"],
             zerolinecolor=BRAND_COLORS["cloud"],
             tickfont=dict(color=BRAND_COLORS["slate"]),
-            titlefont=dict(color=BRAND_COLORS["slate"]),
         ),
         yaxis2=dict(
-            title="累計 (円)",
+            title=dict(
+                text="累計 (円)",
+                font=dict(color=BRAND_COLORS["slate"]),
+            ),
             overlaying="y",
             side="right",
             gridcolor="rgba(0,0,0,0)",
             tickfont=dict(color=BRAND_COLORS["slate"]),
-            titlefont=dict(color=BRAND_COLORS["slate"]),
         ),
         height=420,
         margin=dict(t=60, b=40, l=10, r=10, pad=10),
@@ -3171,16 +3187,20 @@ def render_summary_tab(df: pd.DataFrame, monthly: pd.DataFrame) -> None:
             plot_bgcolor="white",
             paper_bgcolor="white",
             xaxis=dict(
-                title="粗利率",
+                title=dict(
+                    text="粗利率",
+                    font=dict(color=BRAND_COLORS["slate"]),
+                ),
                 gridcolor=BRAND_COLORS["cloud"],
                 tickfont=dict(color=BRAND_COLORS["slate"]),
-                titlefont=dict(color=BRAND_COLORS["slate"]),
             ),
             yaxis=dict(
-                title="件数",
+                title=dict(
+                    text="件数",
+                    font=dict(color=BRAND_COLORS["slate"]),
+                ),
                 gridcolor=BRAND_COLORS["cloud"],
                 tickfont=dict(color=BRAND_COLORS["slate"]),
-                titlefont=dict(color=BRAND_COLORS["slate"]),
             ),
         )
         hist = apply_plotly_theme(hist)


### PR DESCRIPTION
## Summary
- replace deprecated axis `titlefont` usage with explicit title dictionaries that include text and font settings
- apply the new axis configuration across summary, cash flow, histogram, and timeline fallback plots to restore compatibility with Plotly 6

## Testing
- `python - <<'PY'
import plotly.graph_objects as go
from app import compute_monthly_aggregation, load_projects, get_fiscal_year_range, DEFAULT_FISCAL_YEAR, get_brand_template, apply_plotly_theme, BRAND_COLORS

projects_df = load_projects()
monthly = compute_monthly_aggregation(projects_df, get_fiscal_year_range(DEFAULT_FISCAL_YEAR))
trend_fig = go.Figure()
trend_fig.add_bar(x=monthly['年月'], y=monthly['受注金額'], name='受注金額', marker=dict(color=BRAND_COLORS['navy'], line=dict(width=0)))
trend_fig.add_bar(x=monthly['年月'], y=monthly['予定原価'], name='予定原価', marker=dict(color=BRAND_COLORS['sky'], line=dict(width=0)))
trend_fig.add_trace(go.Scatter(x=monthly['年月'], y=monthly['粗利'], mode='lines+markers', name='粗利', marker=dict(color=BRAND_COLORS['gold'], size=8), line=dict(color=BRAND_COLORS['gold'], width=3)))
trend_fig.add_trace(go.Scatter(x=monthly['年月'], y=monthly['粗利率'], mode='lines', name='粗利率', yaxis='y2', line=dict(color=BRAND_COLORS['teal'], width=2, dash='dot')))
trend_fig.update_layout(
    template=get_brand_template(),
    barmode='group',
    plot_bgcolor='white',
    paper_bgcolor='white',
    xaxis=dict(
        title=dict(text='年月', font=dict(color=BRAND_COLORS['slate'])),
        tickfont=dict(color=BRAND_COLORS['slate']),
        gridcolor=BRAND_COLORS['cloud'],
        linecolor=BRAND_COLORS['cloud'],
    ),
    yaxis=dict(
        title=dict(text='金額', font=dict(color=BRAND_COLORS['slate'])),
        gridcolor=BRAND_COLORS['cloud'],
        zerolinecolor=BRAND_COLORS['cloud'],
        tickfont=dict(color=BRAND_COLORS['slate']),
    ),
    yaxis2=dict(
        title=dict(text='粗利率 (%)', font=dict(color=BRAND_COLORS['slate'])),
        overlaying='y',
        side='right',
        gridcolor='rgba(0,0,0,0)',
        tickfont=dict(color=BRAND_COLORS['slate']),
    ),
    height=480,
    margin=dict(t=60, b=40, l=10, r=10, pad=10),
)
apply_plotly_theme(trend_fig)
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68d942a8bbc8832389a9c8e18ebcb892