### PR TITLE
Add project gantt chart to timeline page

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,8 @@ import plotly.graph_objects as go
 import streamlit as st
 from dateutil.relativedelta import relativedelta
 
+from gantt_chart import create_project_gantt_chart
+
 DATA_DIR = "data"
 PROJECT_CSV = os.path.join(DATA_DIR, "projects.csv")
 MASTERS_JSON = os.path.join(DATA_DIR, "masters.json")
@@ -3501,6 +3503,27 @@ def main() -> None:
         st.subheader("タイムライン")
         timeline_fig = create_timeline(enriched_filtered_df, filters, fiscal_range)
         st.plotly_chart(timeline_fig, use_container_width=True)
+
+        st.markdown("### 案件ガントチャート")
+        if enriched_filtered_df.empty:
+            st.info("表示できる案件がありません。フィルタ条件を見直してください。")
+        else:
+            gantt_source = (
+                enriched_filtered_df[["案件名", "着工日", "竣工日"]]
+                .rename(columns={"着工日": "開始日", "竣工日": "終了日"})
+                .copy()
+            )
+            try:
+                gantt_fig = create_project_gantt_chart(gantt_source)
+            except ValueError as exc:
+                st.warning(f"ガントチャートを生成できませんでした: {exc}")
+            else:
+                gantt_fig.update_layout(
+                    title=dict(text=f"{filters.fiscal_year}年度 案件別ガントチャート")
+                )
+                gantt_fig = apply_plotly_theme(gantt_fig)
+                st.plotly_chart(gantt_fig, use_container_width=True)
+
         st.markdown("### 日程スケジュール")
         schedule_fig = create_schedule_chart(enriched_filtered_df, filters, fiscal_range)
         st.plotly_chart(schedule_fig, use_container_width=True)


### PR DESCRIPTION
## Summary
- import the shared gantt chart factory into the Streamlit app
- render a project-level Gantt visual on the Timeline tab with friendly fallbacks

## Testing
- python -m compileall app.py gantt_chart.py

------
https://chatgpt.com/codex/tasks/task_e_68d94aad78ac832382cbc9bd6db51b6a