### PR TITLE
Fix CSV export encoding for Japanese template

### DIFF
--- a/app.py
+++ b/app.py
@@ -2519,14 +2519,15 @@ def render_quick_actions() -> None:
 
 
 def prepare_export(df: Optional[pd.DataFrame], file_format: str = "CSV"):
+    """Export helper that returns bytes suitable for download buttons."""
     if df is None:
-        return b"" if file_format == "Excel" else ""
+        return b""
     if file_format == "Excel":
         buffer = BytesIO()
         df.to_excel(buffer, index=False)
         buffer.seek(0)
         return buffer.getvalue()
-    return df.to_csv(index=False)
+    return df.to_csv(index=False, line_terminator="\r\n").encode("utf-8-sig")
 
 
 def load_uploaded_dataframe(uploaded) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- ensure CSV exports include a UTF-8 BOM so Japanese headers render correctly
- normalize CSV line endings and return bytes from the export helper for consistency

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d94be21d488323882d12fc1a115b8d